### PR TITLE
override CSS to block cooking.nytimes.com popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 ### Update in Aug 2017:
 *	Thank [apank](https://github.com/apank) for adding [Bloomberg](https://www.bloomberg.com/businessweek) to our list.
+*	Thank [strafer](https://github.com/strafer) for creating an issue that [New York Times Cooking section](https://cooking.nytimes.com/) has separate paywall. We fixed it by just injecting CSS to the pages to hide the pop up dialog and still keep JavaScript working as expected. See [this pull request](https://github.com/njuljsong/wsjUnblock/pull/3) for details.
 
 ### Update in Apr 2017:
 *	**Fact**: WSJ has an advertisement popping up *every single time* we read an article, too much!

--- a/css/nyt.css
+++ b/css/nyt.css
@@ -3,25 +3,27 @@
  *
  * there is this class on html and body:
  *   .nytc---modal-window---noScroll {
- *	    height: 100%;
- *	    overflow: hidden;
- *	    position: relative;
- *	};
+ *      height: 100%;
+ *      overflow: hidden;
+ *      position: relative;
+ *   };
  *
  * It causes issues:
- * 	1: unable to scroll
- * 		So we need to override `overflow` to make page scrollable.
- * 	2: images should be lazyloaded but do not load at all
+ *  1: unable to scroll
+ *     So we need to override `overflow` to make page scrollable.
+ *     [ref](https://davidwalsh.name/prevent-body-scrolling)
+ *  2: images should be lazyloaded but are not loaded at all
  *     I just accidently find it out that removing this `height: 100%` will restore javascript's
  * functionality to lazyload images, so we are all set!
- *
- * We do not want to see the pop up for signup, so just hide it
  */
 html {
-	height: auto !important;
-	overflow: scroll !important;
+    height: auto !important;
+    overflow: scroll !important;
 }
 
+/**
+ * We do not want to see the pop up for signup, so just hide it
+ */
 #app-container div[role=dialog] {
     display: none !important;
 }

--- a/css/nyt.css
+++ b/css/nyt.css
@@ -1,0 +1,7 @@
+body {
+    overflow: scroll !important;
+}
+
+#app-container div[role=dialog] {
+    display: none !important;
+}

--- a/css/nyt.css
+++ b/css/nyt.css
@@ -1,5 +1,25 @@
-body {
-    overflow: scroll !important;
+/**
+ * Note about why we need to override these attributes
+ *
+ * there is this class on html and body:
+ *   .nytc---modal-window---noScroll {
+ *	    height: 100%;
+ *	    overflow: hidden;
+ *	    position: relative;
+ *	};
+ *
+ * It causes issues:
+ * 	1: unable to scroll
+ * 		So we need to override `overflow` to make page scrollable.
+ * 	2: images should be lazyloaded but do not load at all
+ *     I just accidently find it out that removing this `height: 100%` will restore javascript's
+ * functionality to lazyload images, so we are all set!
+ *
+ * We do not want to see the pop up for signup, so just hide it
+ */
+html {
+	height: auto !important;
+	overflow: scroll !important;
 }
 
 #app-container div[role=dialog] {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Make WSJ & NYT Great Again",
-  "version": "0.2",
+  "version": "0.3",
   "manifest_version": 2,
   "description": "Get around the paywall for many WSJ, NYT & FT content",
   "homepage_url": "http://blog.jinsongli.com",
@@ -13,6 +13,12 @@
     ],
     "persistent": true
   },
+  "content_scripts": [
+      {
+        "matches": ["https://cooking.nytimes.com/*"],
+        "css" : ["css/nyt.css"]
+      }
+  ],
   "permissions": [
     "webRequest",
     "webRequestBlocking",


### PR DESCRIPTION
`cooking.nytimes.com` wants user to log in, with free trial or subscription. So it pops up a dialog to block the content. 

There is no single javascript file whose functionality is only to pop up the dialog, so we don't want to block the core javascript bundle.

One simple trick is to inject CSS to hide the overlay. it works, but there are side effects. Example: https://cooking.nytimes.com/guides/37-how-to-make-cassoulet will not be able to show videos in the content.

I am exploring better approaches...If you have ideas, please leave a comment!
