### PR TITLE
add philly.com paywall bypass

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -48,6 +48,9 @@ var sites = {
 		js: [
 			"*://*.bizjournals.com/dist/js/article.min.js*"
 		]
+	},
+	philly: {
+		url: "*://*.philly.com",
 	}
 };
 


### PR DESCRIPTION
after the 10 free articles per month, philly.com will have a popup asking the user to subscribe. This commit will remove that.

Verified first by blocking all the cookies from www.philly.com, then eventually adding the url pattern to the code.