### PR TITLE
LinkedIn: modify css for login wall+scroll freeze

### DIFF
--- a/css/linkedin.css
+++ b/css/linkedin.css
@@ -1,0 +1,15 @@
+/**
+ * CSS for removing the login wall and scroll freeze on LinkedIn
+ *
+ * Attributes affected:
+ * - #advocate-modal is the popup window prompting you to log in
+ * - advocate-modal-visible disables scrolling on the page
+ */
+
+#advocate-modal.show {
+  display: none !important;
+}
+
+body.advocate-modal-visible {
+  overflow: visible !important;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,10 @@
       {
         "matches": ["https://cooking.nytimes.com/*"],
         "css" : ["css/nyt.css"]
+      },
+      {
+        "matches": ["https://*.linkedin.com/in/*"],
+        "css": ["css/linkedin.css"]
       }
   ],
   "permissions": [
@@ -38,6 +42,8 @@
     "https://*.washingtonpost.com/*",
     "http://*.washingtonpost.com/*",
     "https://*.bizjournals.com/*",
-    "http://*.bizjournals.com/*"
+    "http://*.bizjournals.com/*",
+    "https://*.linkedin.com/*",
+    "http://*.linkedin.com/*"
    ]
 }


### PR DESCRIPTION
- Similar to the cooking.nytimes.com popup removal in PR #3 in the [wsjUnblock repo]
(https://github.com/njuljsong/wsjUnblock/pull/3)
- NOTE: adaptations from
[the CSS-only repo](https://github.com/geordgez/linkedin-login-wall-css/blob/master/css/login_removal.css):
  - Needed to remove the enclosing `@-moz-document domain(...)`
  - Needed to add `!important` tags since the extension overrides in a
different order from the bookmarklet script injection