### PR TITLE
LinkedIn: remove login wall and scroll freeze [CSS-only]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 *	**Idea**: I changed the referer to facebook or twitter, both are working great again:). The logic is that we can read the full WSJ article if we click through a twitter or facebook link of the article. So far they have not blocked these referers.
 
+*	**Extra**: Add Financial Times `www.ft.com` to our list. FT and WSJ are using the same logic for paywall, so it can be accessed in the same way.
+
 ### How It Works as in July 2016:
 
 #### For Wall Street Journal:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 
 ## Make WSJ & NYTimes Great Again:
 
-#### Get around the paywall for many Wall Street Journal and New York Times content
+#### Get around the paywall for many Wall Street Journal, New York Times and Financial Times content
+
+### Update in Apr 2017:
+*	**Fact**: WSJ has an advertisement popping up *every single time* we read an article, too much!
+*	**Idea**: After checking their code, I find the pop-up ad is triggered by a javascript file, so let's just block it, using the same logic that we blocked the NYTimes gateway javascript.
+*	**Extra**: The pop-up ad will stay disappeared as long as the WSJ developers do not change the javascript names, I am sure they will at some point. So this is a practical but not ideal solution for right now.
 
 ### Update in Jan 2017:
-*	**Fact** WSJ has blocked `https://www.google.com` referer randomly on desktop.
+*	**Fact**: WSJ has blocked `https://www.google.com` referer randomly on desktop.
 
 *	**Idea**: I changed the referer to facebook or twitter, both are working great again:). The logic is that we can read the full WSJ article if we click through a twitter or facebook link of the article. So far they have not blocked these referers.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 ### Update in Aug 2017:
 *	Thank [apank](https://github.com/apank) for adding [Bloomberg](https://www.bloomberg.com/businessweek) to our list.
+*	Thank [strafer](https://github.com/strafer) for creating an issue that [New York Times Cooking section](https://cooking.nytimes.com/) has separate paywall. We fixed it by just injecting CSS to the pages to hide the pop up dialog and still keep JavaScript working as expected. See [this pull request](https://github.com/njuljsong/wsjUnblock/pull/3) for details.
 
 ### Update in Apr 2017:
 *	**Fact**: WSJ has an advertisement popping up *every single time* we read an article, too much!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 
 ## Make WSJ & NYTimes Great Again:
 
-#### Get around the paywall for many Wall Street Journal, New York Times and Financial Times content
+#### Get around the paywalls for Wall Street Journal, New York Times, Financial Times and Bloomberg.
+
+### Update in Aug 2017:
+*	Thank [apank](https://github.com/apank) for adding [Bloomberg](https://www.bloomberg.com/businessweek) to our list.
 
 ### Update in Apr 2017:
 *	**Fact**: WSJ has an advertisement popping up *every single time* we read an article, too much!

--- a/css/nyt.css
+++ b/css/nyt.css
@@ -3,25 +3,27 @@
  *
  * there is this class on html and body:
  *   .nytc---modal-window---noScroll {
- *	    height: 100%;
- *	    overflow: hidden;
- *	    position: relative;
- *	};
+ *      height: 100%;
+ *      overflow: hidden;
+ *      position: relative;
+ *   };
  *
  * It causes issues:
- * 	1: unable to scroll
- * 		So we need to override `overflow` to make page scrollable.
- * 	2: images should be lazyloaded but do not load at all
+ *  1: unable to scroll
+ *     So we need to override `overflow` to make page scrollable.
+ *     [ref](https://davidwalsh.name/prevent-body-scrolling)
+ *  2: images should be lazyloaded but are not loaded at all
  *     I just accidently find it out that removing this `height: 100%` will restore javascript's
  * functionality to lazyload images, so we are all set!
- *
- * We do not want to see the pop up for signup, so just hide it
  */
 html {
-	height: auto !important;
-	overflow: scroll !important;
+    height: auto !important;
+    overflow: scroll !important;
 }
 
+/**
+ * We do not want to see the pop up for signup, so just hide it
+ */
 #app-container div[role=dialog] {
     display: none !important;
 }

--- a/css/nyt.css
+++ b/css/nyt.css
@@ -1,0 +1,7 @@
+body {
+    overflow: scroll !important;
+}
+
+#app-container div[role=dialog] {
+    display: none !important;
+}

--- a/css/nyt.css
+++ b/css/nyt.css
@@ -1,5 +1,25 @@
-body {
-    overflow: scroll !important;
+/**
+ * Note about why we need to override these attributes
+ *
+ * there is this class on html and body:
+ *   .nytc---modal-window---noScroll {
+ *	    height: 100%;
+ *	    overflow: hidden;
+ *	    position: relative;
+ *	};
+ *
+ * It causes issues:
+ * 	1: unable to scroll
+ * 		So we need to override `overflow` to make page scrollable.
+ * 	2: images should be lazyloaded but do not load at all
+ *     I just accidently find it out that removing this `height: 100%` will restore javascript's
+ * functionality to lazyload images, so we are all set!
+ *
+ * We do not want to see the pop up for signup, so just hide it
+ */
+html {
+	height: auto !important;
+	overflow: scroll !important;
 }
 
 #app-container div[role=dialog] {

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,8 @@
     "webRequestBlocking",
     "https://*.wsj.com/*",
     "http://*.wsj.com/*",
+    "https://*.ft.com/*",
+    "http://*.ft.com/*",
     "https://*.nytimes.com/*",
     "http://*.nytimes.com/*",
     "https://*.nyt.com/*",

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Make WSJ & NYT Great Again",
-  "version": "0.1",
+  "version": "0.2",
   "manifest_version": 2,
-  "description": "Get around the paywall for many WSJ & NYT content",
+  "description": "Get around the paywall for many WSJ, NYT & FT content",
   "homepage_url": "http://blog.jinsongli.com",
   "icons": {
     "48": "icons/eric_cartman.png"
@@ -18,6 +18,7 @@
     "webRequestBlocking",
     "https://*.wsj.com/*",
     "http://*.wsj.com/*",
+    "https://*.wsj.net/*",
     "https://*.ft.com/*",
     "http://*.ft.com/*",
     "https://*.nytimes.com/*",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Make WSJ & NYT Great Again",
-  "version": "0.2",
+  "version": "0.3",
   "manifest_version": 2,
   "description": "Get around the paywall for many WSJ, NYT & FT content",
   "homepage_url": "http://blog.jinsongli.com",
@@ -13,6 +13,12 @@
     ],
     "persistent": true
   },
+  "content_scripts": [
+      {
+        "matches": ["https://cooking.nytimes.com/*"],
+        "css" : ["css/nyt.css"]
+      }
+  ],
   "permissions": [
     "webRequest",
     "webRequestBlocking",

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,10 @@
     "https://*.nytimes.com/*",
     "http://*.nytimes.com/*",
     "https://*.nyt.com/*",
-    "http://*.nyt.com/*"
+    "http://*.nyt.com/*",
+    "https://*.bloomberg.com/*",
+    "http://*.bloomberg.com/*",
+    "https://*.bwbx.io/*",
+    "http://*.bwbx.io/*"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -36,6 +36,8 @@
     "https://*.bwbx.io/*",
     "http://*.bwbx.io/*",
     "https://*.washingtonpost.com/*",
-    "http://*.washingtonpost.com/*"
+    "http://*.washingtonpost.com/*",
+    "https://*.bizjournals.com/*",
+    "http://*.bizjournals.com/*"
    ]
 }

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -9,10 +9,6 @@ var newHeader = {
 		name: "Cookie",
 		value: ""
 	},
-	useragent: {
-		name: "User-Agent",
-		value: "Mozilla/5.0 (iPhone; CPU iPhone OS 9_2_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13D15 Safari/601.1"
-	},
 	cachecontrol: {
 		name: "Cache-Control",
 		value: "max-age=0"
@@ -20,21 +16,26 @@ var newHeader = {
 };
 
 // sites that we want to access
-var urls = {
-	wsj: "*://*.wsj.com/*",
-	ft: "*://*.ft.com/*",
+var sites = {
+	wsj: {
+		url: "*://*.wsj.com/*",
+		js: "*://*/*cxense-candy.js" // this one causing a pop up advertisement for every article
+	},
+	ft: {
+		url: "*://*.ft.com/*",
+	},
 	nyt: {
-		gateway: "*://*.com/*mtr.js"
+		js: "*://*.com/*mtr.js" // this one causing a pop up asking for subscription
 	}
 };
 
 chrome.webRequest.onBeforeRequest.addListener(
 	function() {
-		console.log( "we are going to block nytimes gateway javascript" );
+		console.log( "we are going to block some low energy javascripts" );
 		
 		return { cancel: true };
 	}, {
-		urls: [ urls.nyt.gateway ],
+		urls: [ sites.nyt.js, sites.wsj.js ],
 		// target is script
 		types: [ "script" ]
 	},
@@ -43,26 +44,24 @@ chrome.webRequest.onBeforeRequest.addListener(
 
 chrome.webRequest.onBeforeSendHeaders.addListener(
 	function( details ) {
-		console.log( "we are going to override request headers" );
+		console.log( "we are going to override some request headers" );
 
 		// remove existing referer and cookie
 		for ( var i = 0; i < details.requestHeaders.length; i++) {
 			if ( details.requestHeaders[i].name === newHeader.referer.name || details.requestHeaders[i].name === newHeader.cookie.name ) {
-		        details.requestHeaders.splice(i, 1);
-		        i--;
+				details.requestHeaders.splice(i, 1);
+				i--;
 			}
 		}
 
 		// add new referer
 		details.requestHeaders.push( newHeader.referer );
-		// change user agent
-		details.requestHeaders.push( newHeader.useragent );
 		// remove cache
 		details.requestHeaders.push( newHeader.cachecontrol );
 
 		return { requestHeaders: details.requestHeaders };
 	}, {
-		urls: [ urls.wsj, urls.ft ],
+		urls: [ sites.wsj.url, sites.ft.url ],
 		// target is the document that is loaded for a top-level frame
 		types: [ "main_frame" ]
 	},

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -42,6 +42,12 @@ var sites = {
 		js: [
 			"*://*.bwbx.io/s3/javelin/public/javelin/js/pianola/*",
 		]
+	},
+	bizjournals: {
+		url: "*://*.bizjournals.com/*",
+		js: [
+			"*://*.bizjournals.com/dist/js/article.min.js*"
+		]
 	}
 };
 
@@ -59,7 +65,7 @@ var main_frame_urls = Object.values(sites)
 chrome.webRequest.onBeforeRequest.addListener(
 	function() {
 		console.log("we are going to block some low energy javascripts");
-		
+
 		return { cancel: true };
 	}, {
 		urls: script_urls,

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -26,6 +26,10 @@ var sites = {
 	},
 	nyt: {
 		js: "*://*.com/*mtr.js" // this one causing a pop up asking for subscription
+	},
+	bloomberg: {
+		url: "*://*.bloomberg.com/*",
+		js: "*://*.bwbx.io/s3/javelin/public/javelin/js/pianola/*"
 	}
 };
 
@@ -35,7 +39,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 		
 		return { cancel: true };
 	}, {
-		urls: [ sites.nyt.js, sites.wsj.js ],
+		urls: [ sites.nyt.js, sites.wsj.js, sites.bloomberg.js ],
 		// target is script
 		types: [ "script" ]
 	},
@@ -61,7 +65,7 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
 
 		return { requestHeaders: details.requestHeaders };
 	}, {
-		urls: [ sites.wsj.url, sites.ft.url ],
+		urls: [ sites.wsj.url, sites.ft.url, sites.bloomberg.url ],
 		// target is the document that is loaded for a top-level frame
 		types: [ "main_frame" ]
 	},


### PR DESCRIPTION
### Description
Similar to PR #3 for `cooking.nytimes.com`, remove the login modal window that pops up as well as the scroll freeze imposed on profiles where public profile contents are fully loaded.

**NOTE:** this is CSS-only and therefore only works if you hit the "soft" login wall where profile content is loaded. If you browse too many unique profiles (around 10-20) and hit the "hard" login wall, this won't help.

CSS adapted/copied over from [this project repo for creating a CSS-only modifier via bookmarklet](https://github.com/geordgez/linkedin-login-wall-css/)

This is a follow-up to PR #23