### PR TITLE
add Firefox and Edge support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "name": "Make WSJ & NYT Great Again",
-  "version": "0.3",
+  "version": "0.4",
   "manifest_version": 2,
   "description": "Get around the paywall for many WSJ, NYT & FT content",
+  "author": "Jinsong Li",
   "homepage_url": "http://blog.jinsongli.com",
   "icons": {
     "48": "icons/eric_cartman.png"

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -1,6 +1,6 @@
 
 // new http header parameters to override
-var newHeader = {
+const newHeader = {
 	referer: {
 		name: "Referer",
 		value: "https://www.facebook.com", // or "https://www.twitter.com"
@@ -16,7 +16,7 @@ var newHeader = {
 };
 
 // sites that we want to access
-var sites = {
+const sites = {
 	washingtonpost: {
 		js: [
 			"*://*.washingtonpost.com/*pwapi/*.js*", // this one causes paywall/ad-wall lightbox for every article
@@ -68,7 +68,10 @@ var main_frame_urls = Object.values(sites)
                     .map(site => site.url)
                     .filter(url => url);
 
-chrome.webRequest.onBeforeRequest.addListener(
+// add Firefox and Edge support with the global `browser` object
+browser = typeof browser !== "undefined" ? browser : chrome;
+
+browser.webRequest.onBeforeRequest.addListener(
 	function() {
 		console.log("we are going to block some low energy javascripts");
 
@@ -81,7 +84,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 	[ "blocking" ]
 );
 
-chrome.webRequest.onBeforeSendHeaders.addListener(
+browser.webRequest.onBeforeSendHeaders.addListener(
 	function(details) {
 		console.log("we are going to override some request headers");
 


### PR DESCRIPTION
With the awesome idea from @Scrxtchy's [PR](https://github.com/njuljsong/wsjUnblock/pull/17), and a simplified code, we are able to use this extension flawlessly in Firefox(I verified) and Microsoft Edge(I did not, but it seems fine, hehe)

The key is to use `browser` object instead of `chrome` when we use Firefox or Edge:
*  For Firefox,  you can access the APIs using the `browser` namespace. [firefox doc](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API)
*  For Microsoft Edge,  all extension APIs are under the `browser` namespace.[edge doc](https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis)
